### PR TITLE
Add application metrics for RPC latency, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ emulinker/.factorypath
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+emulinker/metrics/

--- a/emulinker/conf/emulinker.cfg
+++ b/emulinker/conf/emulinker.cfg
@@ -120,7 +120,10 @@ server.maxGameNameLength=127
  # Maximum quit message length, 0 to disable
 server.maxQuitMessageLength=100
 
+# Enables server metrics to be monitored and logged.
 metrics.enabled=false
+# How often the metrics should be saved to a file in seconds.
+metrics.loggingFrequencySeconds=15
 
 # Core number of threads to be used. Default value 5.
 server.coreThreadpoolSize=5

--- a/emulinker/conf/emulinker.cfg
+++ b/emulinker/conf/emulinker.cfg
@@ -120,5 +120,5 @@ server.maxGameNameLength=127
  # Maximum quit message length, 0 to disable
 server.maxQuitMessageLength=100
 
- # Core number of threads to be used
-server.coreThreadpoolSize=10
+# Core number of threads to be used. Default value is the number of cores the machine has.
+# server.coreThreadpoolSize=10

--- a/emulinker/conf/emulinker.cfg
+++ b/emulinker/conf/emulinker.cfg
@@ -120,5 +120,7 @@ server.maxGameNameLength=127
  # Maximum quit message length, 0 to disable
 server.maxQuitMessageLength=100
 
-# Core number of threads to be used. Default value is the number of cores the machine has.
-# server.coreThreadpoolSize=10
+metrics.enabled=false
+
+# Core number of threads to be used. Default value 5.
+server.coreThreadpoolSize=5

--- a/emulinker/pom.xml
+++ b/emulinker/pom.xml
@@ -20,6 +20,13 @@
 
   <dependencies>
 
+    <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-jvm -->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+      <version>4.2.3</version>
+    </dependency>
+
     <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -157,12 +164,6 @@
       <artifactId>commons-pool</artifactId>
       <version>1.2</version>
     </dependency>
-
-    <!-- <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.12</version>
-    </dependency> -->
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/emulinker/pom.xml
+++ b/emulinker/pom.xml
@@ -45,11 +45,20 @@
       <version>0.6</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.google.dagger/dagger -->
     <dependency>
       <groupId>com.google.dagger</groupId>
       <artifactId>dagger</artifactId>
-      <version>2.38.1</version>
+      <version>2.39</version>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.google.dagger/dagger-compiler -->
+    <dependency>
+      <groupId>com.google.dagger</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>2.39</version>
+    </dependency>
+
 
     <!-- https://stackoverflow.com/a/62065404/2875073 -->
     <dependency>
@@ -258,8 +267,8 @@
               <path>
                 <groupId>com.google.dagger</groupId>
                 <artifactId>dagger-compiler</artifactId>
-                <version>2.16</version>
-            </path>
+                <version>2.39</version>
+              </path>
             </annotationProcessorPaths>
           </configuration>
         </plugin>

--- a/emulinker/pom.xml
+++ b/emulinker/pom.xml
@@ -20,6 +20,13 @@
 
   <dependencies>
 
+    <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>4.2.3</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.flogger</groupId>
       <artifactId>flogger</artifactId>

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
@@ -18,6 +18,8 @@ public abstract class RuntimeFlags {
 
   public abstract boolean allowSinglePlayer();
 
+  public abstract boolean metricsEnabled();
+
   public abstract boolean touchEmulinker();
 
   public abstract boolean touchKaillera();
@@ -83,9 +85,10 @@ public abstract class RuntimeFlags {
         .setCharset(Charset.forName(config.getString("emulinker.charset")))
         .setChatFloodTime(config.getInt("server.chatFloodTime"))
         .setConnectionTypes(config.getList("server.allowedConnectionTypes"))
-        .setCoreThreadPoolSize(
-            config.getInt("server.coreThreadpoolSize", Runtime.getRuntime().availableProcessors()))
+        // TODO(nue): Experiment with Runtime.getRuntime().availableProcessors().
+        .setCoreThreadPoolSize(config.getInt("server.coreThreadpoolSize", 5))
         .setCreateGameFloodTime(config.getInt("server.createGameFloodTime"))
+        .setMetricsEnabled(config.getBoolean("metrics.enabled", false))
         .setGameAutoFireSensitivity(config.getInt("game.defaultAutoFireSensitivity"))
         .setGameBufferSize(config.getInt("game.bufferSize"))
         .setGameDesynchTimeouts(config.getInt("game.desynchTimeouts"))
@@ -154,6 +157,8 @@ public abstract class RuntimeFlags {
     public abstract Builder setCoreThreadPoolSize(int coreThreadPoolSize);
 
     public abstract Builder setCreateGameFloodTime(int createGameFloodTime);
+
+    public abstract Builder setMetricsEnabled(boolean enableMetrics);
 
     public abstract Builder setGameAutoFireSensitivity(int gameAutoFireSensitivity);
 

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.List;
 import javax.inject.Singleton;
 import org.apache.commons.configuration.Configuration;
@@ -25,6 +26,8 @@ public abstract class RuntimeFlags {
   public abstract boolean touchKaillera();
 
   public abstract Charset charset();
+
+  public abstract Duration metricsLoggingFrequency();
 
   public abstract ImmutableList<String> connectionTypes();
 
@@ -89,6 +92,8 @@ public abstract class RuntimeFlags {
         .setCoreThreadPoolSize(config.getInt("server.coreThreadpoolSize", 5))
         .setCreateGameFloodTime(config.getInt("server.createGameFloodTime"))
         .setMetricsEnabled(config.getBoolean("metrics.enabled", false))
+        .setMetricsLoggingFrequency(
+            Duration.ofSeconds(config.getInt("metrics.loggingFrequencySeconds", 30)))
         .setGameAutoFireSensitivity(config.getInt("game.defaultAutoFireSensitivity"))
         .setGameBufferSize(config.getInt("game.bufferSize"))
         .setGameDesynchTimeouts(config.getInt("game.desynchTimeouts"))
@@ -159,6 +164,8 @@ public abstract class RuntimeFlags {
     public abstract Builder setCreateGameFloodTime(int createGameFloodTime);
 
     public abstract Builder setMetricsEnabled(boolean enableMetrics);
+
+    public abstract Builder setMetricsLoggingFrequency(Duration metricsLoggingFrequency);
 
     public abstract Builder setGameAutoFireSensitivity(int gameAutoFireSensitivity);
 

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
@@ -70,6 +70,8 @@ public abstract class RuntimeFlags {
 
   public abstract String serverWebsite();
 
+  public abstract int v086BufferSize();
+
   public static Builder builder() {
     return new AutoValue_RuntimeFlags.Builder();
   }
@@ -104,6 +106,7 @@ public abstract class RuntimeFlags {
         .setServerWebsite(config.getString("masterList.serverWebsite", ""))
         .setTouchEmulinker(config.getBoolean("masterList.touchEmulinker", false))
         .setTouchKaillera(config.getBoolean("masterList.touchKaillera", false))
+        .setV086BufferSize(config.getInt("controllers.v086.bufferSize", 4096))
         .build();
   }
 
@@ -192,6 +195,8 @@ public abstract class RuntimeFlags {
     public abstract Builder setServerName(String serverName);
 
     public abstract Builder setServerWebsite(String serverWebsite);
+
+    public abstract Builder setV086BufferSize(int v086BufferSize);
 
     protected abstract RuntimeFlags innerBuild();
 

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.java
@@ -83,7 +83,8 @@ public abstract class RuntimeFlags {
         .setCharset(Charset.forName(config.getString("emulinker.charset")))
         .setChatFloodTime(config.getInt("server.chatFloodTime"))
         .setConnectionTypes(config.getList("server.allowedConnectionTypes"))
-        .setCoreThreadPoolSize(config.getInt("server.coreThreadpoolSize", 10))
+        .setCoreThreadPoolSize(
+            config.getInt("server.coreThreadpoolSize", Runtime.getRuntime().availableProcessors()))
         .setCreateGameFloodTime(config.getInt("server.createGameFloodTime"))
         .setGameAutoFireSensitivity(config.getInt("game.defaultAutoFireSensitivity"))
         .setGameBufferSize(config.getInt("game.bufferSize"))

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/connectcontroller/ConnectController.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/connectcontroller/ConnectController.java
@@ -2,6 +2,7 @@ package org.emulinker.kaillera.controller.connectcontroller;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.flogger.FluentLogger;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -46,8 +47,9 @@ public final class ConnectController extends UDPServer {
       ThreadPoolExecutor threadPool,
       Set<KailleraServerController> kailleraServerControllers,
       AccessManager accessManager,
-      Configuration config) {
-    super(/* shutdownOnExit= */ true);
+      Configuration config,
+      MetricRegistry metrics) {
+    super(/* shutdownOnExit= */ true, metrics);
 
     this.threadPool = threadPool;
     this.accessManager = accessManager;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.java
@@ -2,6 +2,7 @@ package org.emulinker.kaillera.controller.v086;
 
 import com.codahale.metrics.MetricRegistry;
 import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import java.net.InetSocketAddress;
 import java.nio.Buffer;
@@ -59,6 +60,11 @@ public final class V086ClientHandler extends PrivateUDPServer implements Kailler
 
   private int clientRetryCount = 0;
   private long lastResend = 0;
+
+  @AssistedFactory
+  public interface Factory {
+    V086ClientHandler create(InetSocketAddress remoteSocketAddress, V086Controller v086Controller);
+  }
 
   @AssistedInject
   public V086ClientHandler(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.java
@@ -1,0 +1,454 @@
+package org.emulinker.kaillera.controller.v086;
+
+import com.codahale.metrics.MetricRegistry;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
+import java.net.InetSocketAddress;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.emulinker.config.RuntimeFlags;
+import org.emulinker.kaillera.controller.messaging.MessageFormatException;
+import org.emulinker.kaillera.controller.messaging.ParseException;
+import org.emulinker.kaillera.controller.v086.action.FatalActionException;
+import org.emulinker.kaillera.controller.v086.action.V086Action;
+import org.emulinker.kaillera.controller.v086.action.V086GameEventHandler;
+import org.emulinker.kaillera.controller.v086.action.V086ServerEventHandler;
+import org.emulinker.kaillera.controller.v086.action.V086UserEventHandler;
+import org.emulinker.kaillera.controller.v086.protocol.V086Bundle;
+import org.emulinker.kaillera.controller.v086.protocol.V086BundleFormatException;
+import org.emulinker.kaillera.controller.v086.protocol.V086Message;
+import org.emulinker.kaillera.model.KailleraUser;
+import org.emulinker.kaillera.model.event.GameEvent;
+import org.emulinker.kaillera.model.event.KailleraEvent;
+import org.emulinker.kaillera.model.event.KailleraEventListener;
+import org.emulinker.kaillera.model.event.ServerEvent;
+import org.emulinker.kaillera.model.event.UserEvent;
+import org.emulinker.net.BindException;
+import org.emulinker.net.PrivateUDPServer;
+import org.emulinker.util.ClientGameDataCache;
+import org.emulinker.util.EmuUtil;
+import org.emulinker.util.GameDataCache;
+
+public final class V086ClientHandler extends PrivateUDPServer implements KailleraEventListener {
+  private final V086Controller v086Controller;
+
+  private KailleraUser user;
+  private int messageNumberCounter = 0;
+  private int prevMessageNumber = -1;
+  private int lastMessageNumber = -1;
+  private GameDataCache clientCache = null;
+  private GameDataCache serverCache = null;
+
+  // private LinkedList<V086Message>	lastMessages			= new LinkedList<V086Message>();
+  private LastMessageBuffer lastMessageBuffer =
+      new LastMessageBuffer(V086Controller.MAX_BUNDLE_SIZE);
+
+  private V086Message[] outMessages = new V086Message[V086Controller.MAX_BUNDLE_SIZE];
+
+  private final ByteBuffer inBuffer;
+  private final ByteBuffer outBuffer;
+
+  private Object inSynch = new Object();
+  private Object outSynch = new Object();
+
+  private long testStart;
+  private long lastMeasurement;
+  private int measurementCount = 0;
+  private int bestTime = Integer.MAX_VALUE;
+
+  private int clientRetryCount = 0;
+  private long lastResend = 0;
+
+  @AssistedInject
+  public V086ClientHandler(
+      MetricRegistry metrics,
+      RuntimeFlags flags,
+      @Assisted InetSocketAddress remoteSocketAddress,
+      @Assisted V086Controller v086Controller) {
+    super(false, remoteSocketAddress.getAddress(), metrics);
+
+    this.v086Controller = v086Controller;
+
+    inBuffer = ByteBuffer.allocateDirect(flags.v086BufferSize());
+    outBuffer = ByteBuffer.allocateDirect(flags.v086BufferSize());
+    inBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    outBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+    resetGameDataCache();
+  }
+
+  @Override
+  public String toString() {
+    if (getBindPort() > 0) return "V086Controller(" + getBindPort() + ")";
+    else return "V086Controller(unbound)";
+  }
+
+  public V086Controller getController() {
+    return v086Controller;
+  }
+
+  public KailleraUser getUser() {
+    return user;
+  }
+
+  public synchronized int getNextMessageNumber() {
+    if (messageNumberCounter > 0xFFFF) messageNumberCounter = 0;
+
+    return messageNumberCounter++;
+  }
+
+  /*
+  public List<V086Message> getLastMessage()
+  {
+  return lastMessages;
+  }
+  */
+
+  public int getPrevMessageNumber() {
+    return prevMessageNumber;
+  }
+
+  public int getLastMessageNumber() {
+    return lastMessageNumber;
+  }
+
+  public GameDataCache getClientGameDataCache() {
+    return clientCache;
+  }
+
+  public GameDataCache getServerGameDataCache() {
+    return serverCache;
+  }
+
+  public void resetGameDataCache() {
+    clientCache = new ClientGameDataCache(256);
+    /*SF MOD - Button Ghosting Patch
+    serverCache = new ServerGameDataCache(256);
+    */
+    serverCache = new ClientGameDataCache(256);
+  }
+
+  public void startSpeedTest() {
+    testStart = lastMeasurement = System.currentTimeMillis();
+    measurementCount = 0;
+  }
+
+  public void addSpeedMeasurement() {
+    int et = (int) (System.currentTimeMillis() - lastMeasurement);
+    if (et < bestTime) bestTime = et;
+    measurementCount++;
+    lastMeasurement = System.currentTimeMillis();
+  }
+
+  public int getSpeedMeasurementCount() {
+    return measurementCount;
+  }
+
+  public int getBestNetworkSpeed() {
+    return bestTime;
+  }
+
+  public int getAverageNetworkSpeed() {
+    return (int) ((lastMeasurement - testStart) / measurementCount);
+  }
+
+  @Override
+  public void bind(int port) throws BindException {
+    super.bind(port);
+  }
+
+  public void start(KailleraUser user) {
+    this.user = user;
+    V086Controller.logger
+        .atFine()
+        .log(
+            toString()
+                + " thread starting (ThreadPool:"
+                + v086Controller.threadPool.getActiveCount()
+                + "/"
+                + v086Controller.threadPool.getPoolSize()
+                + ")");
+    v086Controller.threadPool.execute(this);
+    Thread.yield();
+
+    /*
+    long s = System.currentTimeMillis();
+    while (!isBound() && (System.currentTimeMillis() - s) < 1000)
+    {
+    try
+    {
+    Thread.sleep(100);
+    }
+    catch (Exception e)
+    {
+    logger.atSevere().withCause(e).log("Sleep Interrupted!");
+    }
+    }
+
+    if (!isBound())
+    {
+    logger.atSevere().log("V086ClientHandler failed to start for client from " + getRemoteInetAddress().getHostAddress());
+    return;
+    }
+    */
+
+    V086Controller.logger
+        .atFine()
+        .log(
+            toString()
+                + " thread started (ThreadPool:"
+                + v086Controller.threadPool.getActiveCount()
+                + "/"
+                + v086Controller.threadPool.getPoolSize()
+                + ")");
+    v086Controller.clientHandlers.put(user.getID(), this);
+  }
+
+  @Override
+  public void stop() {
+    synchronized (this) {
+      if (getStopFlag()) return;
+
+      int port = -1;
+      if (isBound()) port = getBindPort();
+      V086Controller.logger.atFine().log(this.toString() + " Stopping!");
+      super.stop();
+
+      if (port > 0) {
+        V086Controller.logger
+            .atFine()
+            .log(
+                toString()
+                    + " returning port "
+                    + port
+                    + " to available port queue: "
+                    + (v086Controller.portRangeQueue.size() + 1)
+                    + " available");
+        v086Controller.portRangeQueue.add(port);
+      }
+    }
+
+    if (user != null) {
+      v086Controller.clientHandlers.remove(user.getID());
+      user.stop();
+      user = null;
+    }
+  }
+
+  @Override
+  protected ByteBuffer getBuffer() {
+    // return ByteBufferMessage.getBuffer(bufferSize);
+    // Cast to avoid issue with java version mismatch:
+    // https://stackoverflow.com/a/61267496/2875073
+    ((Buffer) inBuffer).clear();
+    return inBuffer;
+  }
+
+  @Override
+  protected void releaseBuffer(ByteBuffer buffer) {
+    // ByteBufferMessage.releaseBuffer(buffer);
+    // buffer.clear();
+  }
+
+  @Override
+  protected void handleReceived(ByteBuffer buffer) {
+    V086Bundle inBundle = null;
+
+    try {
+      inBundle = V086Bundle.parse(buffer, lastMessageNumber);
+      // inBundle = V086Bundle.parse(buffer, -1);
+    } catch (ParseException e) {
+      buffer.rewind();
+      V086Controller.logger
+          .atWarning()
+          .withCause(e)
+          .log(toString() + " failed to parse: " + EmuUtil.dumpBuffer(buffer));
+      return;
+    } catch (V086BundleFormatException e) {
+      buffer.rewind();
+      V086Controller.logger
+          .atWarning()
+          .withCause(e)
+          .log(toString() + " received invalid message bundle: " + EmuUtil.dumpBuffer(buffer));
+      return;
+    } catch (MessageFormatException e) {
+      buffer.rewind();
+      V086Controller.logger
+          .atWarning()
+          .withCause(e)
+          .log(toString() + " received invalid message: " + EmuUtil.dumpBuffer(buffer));
+      return;
+    }
+
+    // logger.atFine().log("-> " + inBundle.getNumMessages());
+
+    if (inBundle.getNumMessages() == 0) {
+      V086Controller.logger
+          .atFine()
+          .log(
+              toString()
+                  + " received bundle of "
+                  + inBundle.getNumMessages()
+                  + " messages from "
+                  + user);
+      clientRetryCount++;
+      resend(clientRetryCount);
+      return;
+    } else {
+      clientRetryCount = 0;
+    }
+
+    try {
+      synchronized (inSynch) {
+        V086Message[] messages = inBundle.getMessages();
+        if (inBundle.getNumMessages() == 1) {
+          lastMessageNumber = messages[0].messageNumber();
+
+          V086Action action = v086Controller.actions[messages[0].messageId()];
+          if (action == null) {
+            V086Controller.logger
+                .atSevere()
+                .log("No action defined to handle client message: " + messages[0]);
+          }
+
+          action.performAction(messages[0], this);
+        } else {
+          // read the bundle from back to front to process the oldest messages first
+          for (int i = (inBundle.getNumMessages() - 1); i >= 0; i--) {
+            /**
+             * already extracts messages with higher numbers when parsing, it does not need to be
+             * checked and this causes an error if messageNumber is 0 and lastMessageNumber is
+             * 0xFFFF if (messages[i].getNumber() > lastMessageNumber)
+             */
+            {
+              prevMessageNumber = lastMessageNumber;
+              lastMessageNumber = messages[i].messageNumber();
+
+              if ((prevMessageNumber + 1) != lastMessageNumber) {
+                if (prevMessageNumber == 0xFFFF && lastMessageNumber == 0) {
+                  // exception; do nothing
+                } else {
+                  V086Controller.logger
+                      .atWarning()
+                      .log(
+                          user
+                              + " dropped a packet! ("
+                              + prevMessageNumber
+                              + " to "
+                              + lastMessageNumber
+                              + ")");
+                  user.droppedPacket();
+                }
+              }
+
+              V086Action action = v086Controller.actions[messages[i].messageId()];
+              if (action == null) {
+                V086Controller.logger
+                    .atSevere()
+                    .log("No action defined to handle client message: " + messages[i]);
+                continue;
+              }
+
+              // logger.atFine().log(user + " -> " + message);
+              action.performAction(messages[i], this);
+            }
+          }
+        }
+      }
+    } catch (FatalActionException e) {
+      V086Controller.logger
+          .atWarning()
+          .withCause(e)
+          .log(toString() + " fatal action, closing connection");
+      Thread.yield();
+      stop();
+    }
+  }
+
+  @Override
+  public void actionPerformed(KailleraEvent event) {
+    if (event instanceof GameEvent) {
+      V086GameEventHandler eventHandler = v086Controller.gameEventHandlers.get(event.getClass());
+      if (eventHandler == null) {
+        V086Controller.logger
+            .atSevere()
+            .log(
+                toString()
+                    + " found no GameEventHandler registered to handle game event: "
+                    + event);
+        return;
+      }
+
+      eventHandler.handleEvent((GameEvent) event, this);
+    } else if (event instanceof ServerEvent) {
+      V086ServerEventHandler eventHandler =
+          v086Controller.serverEventHandlers.get(event.getClass());
+      if (eventHandler == null) {
+        V086Controller.logger
+            .atSevere()
+            .log(
+                toString()
+                    + " found no ServerEventHandler registered to handle server event: "
+                    + event);
+        return;
+      }
+
+      eventHandler.handleEvent((ServerEvent) event, this);
+    } else if (event instanceof UserEvent) {
+      V086UserEventHandler eventHandler = v086Controller.userEventHandlers.get(event.getClass());
+      if (eventHandler == null) {
+        V086Controller.logger
+            .atSevere()
+            .log(
+                toString()
+                    + " found no UserEventHandler registered to handle user event: "
+                    + event);
+        return;
+      }
+
+      eventHandler.handleEvent((UserEvent) event, this);
+    }
+  }
+
+  public void resend(int timeoutCounter) {
+
+    synchronized (outSynch) {
+      // if ((System.currentTimeMillis() - lastResend) > (user.getPing()*3))
+      if ((System.currentTimeMillis() - lastResend) > v086Controller.server.getMaxPing()) {
+        // int numToSend = (3+timeoutCounter);
+        int numToSend = (3 * timeoutCounter);
+        if (numToSend > V086Controller.MAX_BUNDLE_SIZE) numToSend = V086Controller.MAX_BUNDLE_SIZE;
+
+        V086Controller.logger.atFine().log(this + ": resending last " + numToSend + " messages");
+        send(null, numToSend);
+        lastResend = System.currentTimeMillis();
+      } else {
+        V086Controller.logger.atFine().log("Skipping resend...");
+      }
+    }
+  }
+
+  public void send(V086Message outMessage) {
+    send(outMessage, 5);
+  }
+
+  public void send(V086Message outMessage, int numToSend) {
+    synchronized (outSynch) {
+      if (outMessage != null) {
+        lastMessageBuffer.add(outMessage);
+      }
+
+      numToSend = lastMessageBuffer.fill(outMessages, numToSend);
+      // System.out.println("Server -> " + numToSend);
+      V086Bundle outBundle = new V086Bundle(outMessages, numToSend);
+      //				logger.atFine().log("<- " + outBundle);
+      outBundle.writeTo(outBuffer);
+      // Cast to avoid issue with java version mismatch:
+      // https://stackoverflow.com/a/61267496/2875073
+      ((Buffer) outBuffer).flip();
+      super.send(outBuffer);
+      ((Buffer) outBuffer).clear();
+    }
+  }
+}

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandlerFactory.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandlerFactory.java
@@ -1,0 +1,9 @@
+package org.emulinker.kaillera.controller.v086;
+
+import dagger.assisted.AssistedFactory;
+import java.net.InetSocketAddress;
+
+@AssistedFactory
+public interface V086ClientHandlerFactory {
+    public V086ClientHandler create(InetSocketAddress remoteSocketAddress, V086Controller v086Controller);
+}

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandlerFactory.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandlerFactory.java
@@ -1,9 +1,0 @@
-package org.emulinker.kaillera.controller.v086;
-
-import dagger.assisted.AssistedFactory;
-import java.net.InetSocketAddress;
-
-@AssistedFactory
-public interface V086ClientHandlerFactory {
-    public V086ClientHandler create(InetSocketAddress remoteSocketAddress, V086Controller v086Controller);
-}

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import java.net.InetSocketAddress;
-import java.nio.*;
 import java.util.*;
 import java.util.concurrent.*;
 import javax.inject.Inject;
@@ -13,14 +12,12 @@ import org.apache.commons.configuration.*;
 import org.emulinker.config.RuntimeFlags;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.KailleraServerController;
-import org.emulinker.kaillera.controller.messaging.*;
 import org.emulinker.kaillera.controller.v086.action.*;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.kaillera.model.exception.*;
 import org.emulinker.net.*;
-import org.emulinker.util.*;
 
 @Singleton
 public final class V086Controller implements KailleraServerController {
@@ -46,7 +43,7 @@ public final class V086Controller implements KailleraServerController {
 
   V086Action[] actions = new V086Action[25];
 
-  private final V086ClientHandlerFactory v086ClientHandlerFactory;
+  private final V086ClientHandler.Factory v086ClientHandlerFactory;
   private final RuntimeFlags flags;
 
   @Inject
@@ -77,7 +74,7 @@ public final class V086Controller implements KailleraServerController {
       GameInfoAction gameInfoAction,
       GameTimeoutAction gameTimeoutAction,
       InfoMessageAction infoMessageAction,
-      V086ClientHandlerFactory v086ClientHandlerFactory,
+      V086ClientHandler.Factory v086ClientHandlerFactory,
       RuntimeFlags flags) {
     this.v086ClientHandlerFactory = v086ClientHandlerFactory;
     this.flags = flags;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.java
@@ -10,6 +10,7 @@ import java.util.concurrent.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.configuration.*;
+import org.emulinker.config.RuntimeFlags;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.KailleraServerController;
 import org.emulinker.kaillera.controller.messaging.*;
@@ -23,28 +24,30 @@ import org.emulinker.util.*;
 
 @Singleton
 public final class V086Controller implements KailleraServerController {
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+  static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private int MAX_BUNDLE_SIZE = 9;
+  static final int MAX_BUNDLE_SIZE = 9;
 
-  private int bufferSize = 4096;
   private boolean isRunning = false;
 
-  private ThreadPoolExecutor threadPool;
-  private KailleraServer server;
+  ThreadPoolExecutor threadPool;
+  KailleraServer server;
   private String[] clientTypes;
-  private Map<Integer, V086ClientHandler> clientHandlers =
+  Map<Integer, V086ClientHandler> clientHandlers =
       new ConcurrentHashMap<Integer, V086ClientHandler>();
 
   private int portRangeStart;
   private int extraPorts;
-  private Queue<Integer> portRangeQueue = new ConcurrentLinkedQueue<Integer>();
+  Queue<Integer> portRangeQueue = new ConcurrentLinkedQueue<Integer>();
 
-  private final ImmutableMap<Class<?>, V086ServerEventHandler> serverEventHandlers;
-  private final ImmutableMap<Class<?>, V086GameEventHandler> gameEventHandlers;
-  private final ImmutableMap<Class<?>, V086UserEventHandler> userEventHandlers;
+  final ImmutableMap<Class<?>, V086ServerEventHandler> serverEventHandlers;
+  final ImmutableMap<Class<?>, V086GameEventHandler> gameEventHandlers;
+  final ImmutableMap<Class<?>, V086UserEventHandler> userEventHandlers;
 
-  private V086Action[] actions = new V086Action[25];
+  V086Action[] actions = new V086Action[25];
+
+  private final V086ClientHandlerFactory v086ClientHandlerFactory;
+  private final RuntimeFlags flags;
 
   @Inject
   V086Controller(
@@ -73,10 +76,13 @@ public final class V086Controller implements KailleraServerController {
       PlayerDesynchAction playerDesynchAction,
       GameInfoAction gameInfoAction,
       GameTimeoutAction gameTimeoutAction,
-      InfoMessageAction infoMessageAction) {
+      InfoMessageAction infoMessageAction,
+      V086ClientHandlerFactory v086ClientHandlerFactory,
+      RuntimeFlags flags) {
+    this.v086ClientHandlerFactory = v086ClientHandlerFactory;
+    this.flags = flags;
     this.threadPool = threadPool;
     this.server = server;
-    this.bufferSize = config.getInt("controllers.v086.bufferSize");
     this.clientTypes = config.getStringArray("controllers.v086.clientTypes.clientType");
 
     this.portRangeStart = config.getInt("controllers.v086.portRangeStart");
@@ -94,7 +100,8 @@ public final class V086Controller implements KailleraServerController {
             + maxPort
             + ".  Make sure these ports are open in your firewall!");
 
-    Preconditions.checkArgument(bufferSize > 0, "controllers.v086.bufferSize must be > 0");
+    Preconditions.checkArgument(
+        flags.v086BufferSize() > 0, "controllers.v086.bufferSize must be > 0");
 
     // array access should be faster than a hash and we won't have to create
     // a new Integer each time
@@ -171,7 +178,7 @@ public final class V086Controller implements KailleraServerController {
 
   @Override
   public int getBufferSize() {
-    return bufferSize;
+    return flags.v086BufferSize();
   }
 
   public final ImmutableMap<Class<?>, V086ServerEventHandler> getServerEventHandlers() {
@@ -208,7 +215,7 @@ public final class V086Controller implements KailleraServerController {
       throws ServerFullException, NewConnectionException {
     if (!isRunning) throw new NewConnectionException("Controller is not running");
 
-    V086ClientHandler clientHandler = new V086ClientHandler(clientSocketAddress);
+    V086ClientHandler clientHandler = v086ClientHandlerFactory.create(clientSocketAddress, this);
     KailleraUser user = server.newConnection(clientSocketAddress, protocol, clientHandler);
 
     int boundPort = -1;
@@ -266,383 +273,5 @@ public final class V086Controller implements KailleraServerController {
     for (V086ClientHandler clientHandler : clientHandlers.values()) clientHandler.stop();
 
     clientHandlers.clear();
-  }
-
-  public class V086ClientHandler extends PrivateUDPServer implements KailleraEventListener {
-    private KailleraUser user;
-    private int messageNumberCounter = 0;
-    private int prevMessageNumber = -1;
-    private int lastMessageNumber = -1;
-    private GameDataCache clientCache = null;
-    private GameDataCache serverCache = null;
-
-    // private LinkedList<V086Message>	lastMessages			= new LinkedList<V086Message>();
-    private LastMessageBuffer lastMessageBuffer = new LastMessageBuffer(MAX_BUNDLE_SIZE);
-
-    private V086Message[] outMessages = new V086Message[MAX_BUNDLE_SIZE];
-
-    private ByteBuffer inBuffer = ByteBuffer.allocateDirect(bufferSize);
-    private ByteBuffer outBuffer = ByteBuffer.allocateDirect(bufferSize);
-
-    private Object inSynch = new Object();
-    private Object outSynch = new Object();
-
-    private long testStart;
-    private long lastMeasurement;
-    private int measurementCount = 0;
-    private int bestTime = Integer.MAX_VALUE;
-
-    private int clientRetryCount = 0;
-    private long lastResend = 0;
-
-    private V086ClientHandler(InetSocketAddress remoteSocketAddress) {
-      super(false, remoteSocketAddress.getAddress());
-
-      inBuffer.order(ByteOrder.LITTLE_ENDIAN);
-      outBuffer.order(ByteOrder.LITTLE_ENDIAN);
-
-      resetGameDataCache();
-    }
-
-    @Override
-    public String toString() {
-      if (getBindPort() > 0) return "V086Controller(" + getBindPort() + ")";
-      else return "V086Controller(unbound)";
-    }
-
-    public V086Controller getController() {
-      return V086Controller.this;
-    }
-
-    public KailleraUser getUser() {
-      return user;
-    }
-
-    public synchronized int getNextMessageNumber() {
-      if (messageNumberCounter > 0xFFFF) messageNumberCounter = 0;
-
-      return messageNumberCounter++;
-    }
-
-    /*
-    public List<V086Message> getLastMessage()
-    {
-    return lastMessages;
-    }
-    */
-
-    public int getPrevMessageNumber() {
-      return prevMessageNumber;
-    }
-
-    public int getLastMessageNumber() {
-      return lastMessageNumber;
-    }
-
-    public GameDataCache getClientGameDataCache() {
-      return clientCache;
-    }
-
-    public GameDataCache getServerGameDataCache() {
-      return serverCache;
-    }
-
-    public void resetGameDataCache() {
-      clientCache = new ClientGameDataCache(256);
-      /*SF MOD - Button Ghosting Patch
-      serverCache = new ServerGameDataCache(256);
-      */
-      serverCache = new ClientGameDataCache(256);
-    }
-
-    public void startSpeedTest() {
-      testStart = lastMeasurement = System.currentTimeMillis();
-      measurementCount = 0;
-    }
-
-    public void addSpeedMeasurement() {
-      int et = (int) (System.currentTimeMillis() - lastMeasurement);
-      if (et < bestTime) bestTime = et;
-      measurementCount++;
-      lastMeasurement = System.currentTimeMillis();
-    }
-
-    public int getSpeedMeasurementCount() {
-      return measurementCount;
-    }
-
-    public int getBestNetworkSpeed() {
-      return bestTime;
-    }
-
-    public int getAverageNetworkSpeed() {
-      return (int) ((lastMeasurement - testStart) / measurementCount);
-    }
-
-    @Override
-    public void bind(int port) throws BindException {
-      super.bind(port);
-    }
-
-    public void start(KailleraUser user) {
-      this.user = user;
-      logger.atFine().log(
-          toString()
-              + " thread starting (ThreadPool:"
-              + threadPool.getActiveCount()
-              + "/"
-              + threadPool.getPoolSize()
-              + ")");
-      threadPool.execute(this);
-      Thread.yield();
-
-      /*
-      long s = System.currentTimeMillis();
-      while (!isBound() && (System.currentTimeMillis() - s) < 1000)
-      {
-      try
-      {
-      Thread.sleep(100);
-      }
-      catch (Exception e)
-      {
-      logger.atSevere().withCause(e).log("Sleep Interrupted!");
-      }
-      }
-
-      if (!isBound())
-      {
-      logger.atSevere().log("V086ClientHandler failed to start for client from " + getRemoteInetAddress().getHostAddress());
-      return;
-      }
-      */
-
-      logger.atFine().log(
-          toString()
-              + " thread started (ThreadPool:"
-              + threadPool.getActiveCount()
-              + "/"
-              + threadPool.getPoolSize()
-              + ")");
-      clientHandlers.put(user.getID(), this);
-    }
-
-    @Override
-    public void stop() {
-      synchronized (this) {
-        if (getStopFlag()) return;
-
-        int port = -1;
-        if (isBound()) port = getBindPort();
-        logger.atFine().log(this.toString() + " Stopping!");
-        super.stop();
-
-        if (port > 0) {
-          logger.atFine().log(
-              toString()
-                  + " returning port "
-                  + port
-                  + " to available port queue: "
-                  + (portRangeQueue.size() + 1)
-                  + " available");
-          portRangeQueue.add(port);
-        }
-      }
-
-      if (user != null) {
-        clientHandlers.remove(user.getID());
-        user.stop();
-        user = null;
-      }
-    }
-
-    @Override
-    protected ByteBuffer getBuffer() {
-      // return ByteBufferMessage.getBuffer(bufferSize);
-      // Cast to avoid issue with java version mismatch:
-      // https://stackoverflow.com/a/61267496/2875073
-      ((Buffer) inBuffer).clear();
-      return inBuffer;
-    }
-
-    @Override
-    protected void releaseBuffer(ByteBuffer buffer) {
-      // ByteBufferMessage.releaseBuffer(buffer);
-      // buffer.clear();
-    }
-
-    @Override
-    protected void handleReceived(ByteBuffer buffer) {
-      V086Bundle inBundle = null;
-
-      try {
-        inBundle = V086Bundle.parse(buffer, lastMessageNumber);
-        // inBundle = V086Bundle.parse(buffer, -1);
-      } catch (ParseException e) {
-        buffer.rewind();
-        logger.atWarning().withCause(e).log(
-            toString() + " failed to parse: " + EmuUtil.dumpBuffer(buffer));
-        return;
-      } catch (V086BundleFormatException e) {
-        buffer.rewind();
-        logger.atWarning().withCause(e).log(
-            toString() + " received invalid message bundle: " + EmuUtil.dumpBuffer(buffer));
-        return;
-      } catch (MessageFormatException e) {
-        buffer.rewind();
-        logger.atWarning().withCause(e).log(
-            toString() + " received invalid message: " + EmuUtil.dumpBuffer(buffer));
-        return;
-      }
-
-      // logger.atFine().log("-> " + inBundle.getNumMessages());
-
-      if (inBundle.getNumMessages() == 0) {
-        logger.atFine().log(
-            toString()
-                + " received bundle of "
-                + inBundle.getNumMessages()
-                + " messages from "
-                + user);
-        clientRetryCount++;
-        resend(clientRetryCount);
-        return;
-      } else {
-        clientRetryCount = 0;
-      }
-
-      try {
-        synchronized (inSynch) {
-          V086Message[] messages = inBundle.getMessages();
-          if (inBundle.getNumMessages() == 1) {
-            lastMessageNumber = messages[0].messageNumber();
-
-            V086Action action = actions[messages[0].messageId()];
-            if (action == null) {
-              logger.atSevere().log("No action defined to handle client message: " + messages[0]);
-            }
-
-            action.performAction(messages[0], this);
-          } else {
-            // read the bundle from back to front to process the oldest messages first
-            for (int i = (inBundle.getNumMessages() - 1); i >= 0; i--) {
-              /**
-               * already extracts messages with higher numbers when parsing, it does not need to be
-               * checked and this causes an error if messageNumber is 0 and lastMessageNumber is
-               * 0xFFFF if (messages[i].getNumber() > lastMessageNumber)
-               */
-              {
-                prevMessageNumber = lastMessageNumber;
-                lastMessageNumber = messages[i].messageNumber();
-
-                if ((prevMessageNumber + 1) != lastMessageNumber) {
-                  if (prevMessageNumber == 0xFFFF && lastMessageNumber == 0) {
-                    // exception; do nothing
-                  } else {
-                    logger.atWarning().log(
-                        user
-                            + " dropped a packet! ("
-                            + prevMessageNumber
-                            + " to "
-                            + lastMessageNumber
-                            + ")");
-                    user.droppedPacket();
-                  }
-                }
-
-                V086Action action = actions[messages[i].messageId()];
-                if (action == null) {
-                  logger.atSevere().log(
-                      "No action defined to handle client message: " + messages[i]);
-                  continue;
-                }
-
-                // logger.atFine().log(user + " -> " + message);
-                action.performAction(messages[i], this);
-              }
-            }
-          }
-        }
-      } catch (FatalActionException e) {
-        logger.atWarning().withCause(e).log(toString() + " fatal action, closing connection");
-        Thread.yield();
-        stop();
-      }
-    }
-
-    @Override
-    public void actionPerformed(KailleraEvent event) {
-      if (event instanceof GameEvent) {
-        V086GameEventHandler eventHandler = gameEventHandlers.get(event.getClass());
-        if (eventHandler == null) {
-          logger.atSevere().log(
-              toString() + " found no GameEventHandler registered to handle game event: " + event);
-          return;
-        }
-
-        eventHandler.handleEvent((GameEvent) event, this);
-      } else if (event instanceof ServerEvent) {
-        V086ServerEventHandler eventHandler = serverEventHandlers.get(event.getClass());
-        if (eventHandler == null) {
-          logger.atSevere().log(
-              toString()
-                  + " found no ServerEventHandler registered to handle server event: "
-                  + event);
-          return;
-        }
-
-        eventHandler.handleEvent((ServerEvent) event, this);
-      } else if (event instanceof UserEvent) {
-        V086UserEventHandler eventHandler = userEventHandlers.get(event.getClass());
-        if (eventHandler == null) {
-          logger.atSevere().log(
-              toString() + " found no UserEventHandler registered to handle user event: " + event);
-          return;
-        }
-
-        eventHandler.handleEvent((UserEvent) event, this);
-      }
-    }
-
-    public void resend(int timeoutCounter) {
-
-      synchronized (outSynch) {
-        // if ((System.currentTimeMillis() - lastResend) > (user.getPing()*3))
-        if ((System.currentTimeMillis() - lastResend) > server.getMaxPing()) {
-          // int numToSend = (3+timeoutCounter);
-          int numToSend = (3 * timeoutCounter);
-          if (numToSend > MAX_BUNDLE_SIZE) numToSend = MAX_BUNDLE_SIZE;
-
-          logger.atFine().log(this + ": resending last " + numToSend + " messages");
-          send(null, numToSend);
-          lastResend = System.currentTimeMillis();
-        } else {
-          logger.atFine().log("Skipping resend...");
-        }
-      }
-    }
-
-    public void send(V086Message outMessage) {
-      send(outMessage, 5);
-    }
-
-    public void send(V086Message outMessage, int numToSend) {
-      synchronized (outSynch) {
-        if (outMessage != null) {
-          lastMessageBuffer.add(outMessage);
-        }
-
-        numToSend = lastMessageBuffer.fill(outMessages, numToSend);
-        // System.out.println("Server -> " + numToSend);
-        V086Bundle outBundle = new V086Bundle(outMessages, numToSend);
-        //				logger.atFine().log("<- " + outBundle);
-        outBundle.writeTo(outBuffer);
-        // Cast to avoid issue with java version mismatch:
-        // https://stackoverflow.com/a/61267496/2875073
-        ((Buffer) outBuffer).flip();
-        super.send(outBuffer);
-        ((Buffer) outBuffer).clear();
-      }
-    }
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.java
@@ -5,7 +5,7 @@ import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.java
@@ -7,7 +7,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.exception.ActionException;
 import org.emulinker.kaillera.model.impl.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.KailleraUser;
 import org.emulinker.kaillera.model.exception.GameDataException;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.kaillera.model.exception.ActionException;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CloseGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CloseGameAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.CloseGame;
 import org.emulinker.kaillera.model.event.*;
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.kaillera.model.exception.ActionException;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.KailleraUser;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDesynchAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDesynchAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.GameChat_Notification;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.util.EmuLang;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameInfoAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameInfoAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.GameChat_Notification;
 import org.emulinker.kaillera.model.event.*;
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameKickAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameKickAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.exception.GameKickException;
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.java
@@ -6,7 +6,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.exception.ActionException;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameStatusAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameStatusAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.GameStatus;
 import org.emulinker.kaillera.model.KailleraGame;
 import org.emulinker.kaillera.model.KailleraUser;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameTimeoutAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameTimeoutAction.java
@@ -3,7 +3,7 @@ package org.emulinker.kaillera.controller.v086.action;
 import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.model.KailleraUser;
 import org.emulinker.kaillera.model.event.*;
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/InfoMessageAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/InfoMessageAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.InformationMessage;
 import org.emulinker.kaillera.model.event.*;
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.java
@@ -5,7 +5,7 @@ import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.java
@@ -2,7 +2,7 @@ package org.emulinker.kaillera.controller.v086.action;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 
 @Singleton

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.java
@@ -5,7 +5,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.access.AccessManager;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.*;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/PlayerDesynchAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/PlayerDesynchAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.GameChat_Notification;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.util.EmuLang;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.KailleraUser;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.KailleraUser;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.KailleraGame;
 import org.emulinker.kaillera.model.event.*;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.java
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.emulinker.kaillera.controller.messaging.MessageFormatException;
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.kaillera.model.event.*;
 import org.emulinker.kaillera.model.exception.UserReadyException;

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.java
@@ -1,6 +1,6 @@
 package org.emulinker.kaillera.controller.v086.action;
 
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.controller.v086.protocol.V086Message;
 
 public interface V086Action<T extends V086Message> {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.java
@@ -1,6 +1,6 @@
 package org.emulinker.kaillera.controller.v086.action;
 
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.model.event.GameEvent;
 
 public interface V086GameEventHandler<T extends GameEvent> {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.java
@@ -1,6 +1,6 @@
 package org.emulinker.kaillera.controller.v086.action;
 
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.model.event.ServerEvent;
 
 public interface V086ServerEventHandler<T extends ServerEvent> {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.java
@@ -1,6 +1,6 @@
 package org.emulinker.kaillera.controller.v086.action;
 
-import org.emulinker.kaillera.controller.v086.V086Controller.V086ClientHandler;
+import org.emulinker.kaillera.controller.v086.V086ClientHandler;
 import org.emulinker.kaillera.model.event.UserEvent;
 
 public interface V086UserEventHandler<T extends UserEvent> {

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import dagger.Component;
 import javax.inject.Singleton;
 import org.apache.commons.configuration.Configuration;
+import org.emulinker.config.RuntimeFlags;
 import org.emulinker.kaillera.access.AccessManager2;
 import org.emulinker.kaillera.controller.KailleraServerController;
 import org.emulinker.kaillera.controller.connectcontroller.ConnectController;
@@ -29,4 +30,6 @@ public abstract class AppComponent {
   public abstract MasterListUpdaterImpl getMasterListUpdaterImpl();
 
   public abstract MetricRegistry getMetricRegistry();
+
+  public abstract RuntimeFlags getRuntimeFlags();
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.java
@@ -1,5 +1,6 @@
 package org.emulinker.kaillera.pico;
 
+import com.codahale.metrics.MetricRegistry;
 import dagger.Component;
 import javax.inject.Singleton;
 import org.apache.commons.configuration.Configuration;
@@ -26,4 +27,6 @@ public abstract class AppComponent {
   public abstract KailleraServer getKailleraServer();
 
   public abstract MasterListUpdaterImpl getMasterListUpdaterImpl();
+
+  public abstract MetricRegistry getMetricRegistry();
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.java
@@ -2,6 +2,7 @@ package org.emulinker.kaillera.pico;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.codahale.metrics.MetricRegistry;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -9,6 +10,7 @@ import dagger.multibindings.IntoSet;
 import java.nio.charset.Charset;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+import javax.inject.Singleton;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.emulinker.config.RuntimeFlags;
@@ -59,6 +61,12 @@ public abstract class AppModule {
         60L,
         SECONDS,
         new SynchronousQueue<Runnable>());
+  }
+
+  @Provides
+  @Singleton
+  public static MetricRegistry provideMetricRegistry() {
+    return new MetricRegistry();
   }
 
   @Binds

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
@@ -5,6 +5,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.codahale.metrics.CsvReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.common.flogger.FluentLogger;
 import java.io.File;
 import java.time.Instant;
@@ -45,12 +47,17 @@ public class PicoStarter {
     File metricsDir = new File("./metrics/");
     metricsDir.mkdirs();
     MetricRegistry metrics = component.getMetricRegistry();
-    CsvReporter reporter =
-        CsvReporter.forRegistry(metrics)
-            .formatFor(Locale.US)
-            .convertRatesTo(SECONDS)
-            .convertDurationsTo(MILLISECONDS)
-            .build(metricsDir);
-    reporter.start(5, SECONDS);
+    metrics.registerAll(new ThreadStatesGaugeSet());
+    metrics.registerAll(new MemoryUsageGaugeSet());
+
+    if (component.getRuntimeFlags().metricsEnabled()) {
+      CsvReporter reporter =
+          CsvReporter.forRegistry(metrics)
+              .formatFor(Locale.US)
+              .convertRatesTo(SECONDS)
+              .convertDurationsTo(MILLISECONDS)
+              .build(metricsDir);
+      reporter.start(15, SECONDS);
+    }
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
@@ -1,5 +1,11 @@
 package org.emulinker.kaillera.pico;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.flogger.FluentLogger;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -34,5 +40,23 @@ public class PicoStarter {
     component.getServer().start();
     component.getKailleraServer().start();
     component.getMasterListUpdaterImpl().start();
+
+    MetricRegistry metrics = component.getMetricRegistry();
+    ConsoleReporter reporter =
+        ConsoleReporter.forRegistry(metrics)
+            .convertRatesTo(SECONDS)
+            .convertDurationsTo(MILLISECONDS)
+            .build();
+    reporter.start(5, SECONDS);
+
+    Meter requests = metrics.meter("requests");
+    requests.mark();
+    requests.mark();
+    requests.mark();
+    requests.mark();
+    requests.mark();
+    requests.mark();
+    requests.mark();
+    requests.mark();
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/PicoStarter.java
@@ -3,13 +3,14 @@ package org.emulinker.kaillera.pico;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.codahale.metrics.ConsoleReporter;
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.CsvReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.flogger.FluentLogger;
+import java.io.File;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class PicoStarter {
   public static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -41,22 +42,15 @@ public class PicoStarter {
     component.getKailleraServer().start();
     component.getMasterListUpdaterImpl().start();
 
+    File metricsDir = new File("./metrics/");
+    metricsDir.mkdirs();
     MetricRegistry metrics = component.getMetricRegistry();
-    ConsoleReporter reporter =
-        ConsoleReporter.forRegistry(metrics)
+    CsvReporter reporter =
+        CsvReporter.forRegistry(metrics)
+            .formatFor(Locale.US)
             .convertRatesTo(SECONDS)
             .convertDurationsTo(MILLISECONDS)
-            .build();
+            .build(metricsDir);
     reporter.start(5, SECONDS);
-
-    Meter requests = metrics.meter("requests");
-    requests.mark();
-    requests.mark();
-    requests.mark();
-    requests.mark();
-    requests.mark();
-    requests.mark();
-    requests.mark();
-    requests.mark();
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/relay/KailleraRelay.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/relay/KailleraRelay.java
@@ -1,6 +1,11 @@
 package org.emulinker.kaillera.relay;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.google.common.flogger.FluentLogger;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
 import java.net.InetSocketAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -9,19 +14,44 @@ import org.emulinker.kaillera.controller.messaging.MessageFormatException;
 import org.emulinker.net.UDPRelay;
 import org.emulinker.util.EmuUtil;
 
-public class KailleraRelay extends UDPRelay {
+/** @deprecated This doesn't seem to be used anywhere! Maybe we can get rid of it. */
+@Deprecated(forRemoval = true)
+final class KailleraRelay extends UDPRelay {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  public static void main(String args[]) throws Exception {
-    int localPort = Integer.parseInt(args[0]);
-    String serverIP = args[1];
-    int serverPort = Integer.parseInt(args[2]);
+  private final V086Relay.Factory v086RelayFactory;
 
-    new KailleraRelay(localPort, new InetSocketAddress(serverIP, serverPort));
+  private final Timer clientToServerRequests;
+  private final Timer serverToClientRequests;
+
+  // TODO(nue): Can we just remove this?
+  // public static void main(String args[]) throws Exception {
+  //   int localPort = Integer.parseInt(args[0]);
+  //   String serverIP = args[1];
+  //   int serverPort = Integer.parseInt(args[2]);
+
+  //   new KailleraRelay(localPort, new InetSocketAddress(serverIP, serverPort), new
+  // MetricRegistry());
+  // }
+
+  @AssistedFactory
+  public static interface Factory {
+    public KailleraRelay create(int listenPort, InetSocketAddress serverSocketAddress);
   }
 
-  public KailleraRelay(int listenPort, InetSocketAddress serverSocketAddress) throws Exception {
+  @AssistedInject
+  KailleraRelay(
+      @Assisted int listenPort,
+      @Assisted InetSocketAddress serverSocketAddress,
+      MetricRegistry metrics,
+      V086Relay.Factory v086RelayFactory) {
     super(listenPort, serverSocketAddress);
+
+    this.v086RelayFactory = v086RelayFactory;
+    this.clientToServerRequests =
+        metrics.timer(MetricRegistry.name(KailleraRelay.class, "clientToServerRequests"));
+    this.serverToClientRequests =
+        metrics.timer(MetricRegistry.name(KailleraRelay.class, "serverToClientRequests"));
   }
 
   @Override
@@ -32,81 +62,88 @@ public class KailleraRelay extends UDPRelay {
   @Override
   protected ByteBuffer processClientToServer(
       ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
-    ConnectMessage inMessage = null;
+    try (final Timer.Context context = clientToServerRequests.time()) {
+      ConnectMessage inMessage = null;
 
-    try {
-      inMessage = ConnectMessage.parse(receiveBuffer);
-    } catch (MessageFormatException e) {
-      logger.atWarning().withCause(e).log("Unrecognized message format!");
-      return null;
+      try {
+        inMessage = ConnectMessage.parse(receiveBuffer);
+      } catch (MessageFormatException e) {
+        logger.atWarning().withCause(e).log("Unrecognized message format!");
+        return null;
+      }
+
+      logger.atFine().log(
+          EmuUtil.formatSocketAddress(fromAddress)
+              + " -> "
+              + EmuUtil.formatSocketAddress(toAddress)
+              + ": "
+              + inMessage);
+
+      if (inMessage instanceof ConnectMessage_HELLO) {
+        ConnectMessage_HELLO clientTypeMessage = (ConnectMessage_HELLO) inMessage;
+        logger.atInfo().log("Client version is " + clientTypeMessage.getProtocol());
+      } else {
+        logger.atWarning().log("Client sent an invalid message: " + inMessage);
+        return null;
+      }
+
+      ByteBuffer sendBuffer = ByteBuffer.allocate(receiveBuffer.limit());
+      receiveBuffer.rewind();
+      sendBuffer.put(receiveBuffer);
+      // Cast to avoid issue with java version mismatch:
+      // https://stackoverflow.com/a/61267496/2875073
+      ((Buffer) sendBuffer).flip();
+      return sendBuffer;
     }
-
-    logger.atFine().log(
-        EmuUtil.formatSocketAddress(fromAddress)
-            + " -> "
-            + EmuUtil.formatSocketAddress(toAddress)
-            + ": "
-            + inMessage);
-
-    if (inMessage instanceof ConnectMessage_HELLO) {
-      ConnectMessage_HELLO clientTypeMessage = (ConnectMessage_HELLO) inMessage;
-      logger.atInfo().log("Client version is " + clientTypeMessage.getProtocol());
-    } else {
-      logger.atWarning().log("Client sent an invalid message: " + inMessage);
-      return null;
-    }
-
-    ByteBuffer sendBuffer = ByteBuffer.allocate(receiveBuffer.limit());
-    receiveBuffer.rewind();
-    sendBuffer.put(receiveBuffer);
-    // Cast to avoid issue with java version mismatch: https://stackoverflow.com/a/61267496/2875073
-    ((Buffer) sendBuffer).flip();
-    return sendBuffer;
   }
 
   @Override
   protected ByteBuffer processServerToClient(
       ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
-    ConnectMessage inMessage = null;
-
-    try {
-      inMessage = ConnectMessage.parse(receiveBuffer);
-    } catch (MessageFormatException e) {
-      logger.atWarning().withCause(e).log("Unrecognized message format!");
-      return null;
-    }
-
-    logger.atFine().log(
-        EmuUtil.formatSocketAddress(fromAddress)
-            + " -> "
-            + EmuUtil.formatSocketAddress(toAddress)
-            + ": "
-            + inMessage);
-
-    if (inMessage instanceof ConnectMessage_HELLOD00D) {
-      ConnectMessage_HELLOD00D portMsg = (ConnectMessage_HELLOD00D) inMessage;
-      logger.atInfo().log("Starting client relay on port " + (portMsg.getPort() - 1));
+    try (final Timer.Context context = serverToClientRequests.time()) {
+      ConnectMessage inMessage = null;
 
       try {
-        new V086Relay(
-            portMsg.getPort(),
-            new InetSocketAddress(getServerSocketAddress().getAddress(), portMsg.getPort()));
-      } catch (Exception e) {
-        logger.atSevere().withCause(e).log("Failed to start!");
+        inMessage = ConnectMessage.parse(receiveBuffer);
+      } catch (MessageFormatException e) {
+        logger.atWarning().withCause(e).log("Unrecognized message format!");
         return null;
       }
-    } else if (inMessage instanceof ConnectMessage_TOO) {
-      logger.atWarning().log("Failed to connect: Server is FULL!");
-    } else {
-      logger.atWarning().log("Server sent an invalid message: " + inMessage);
-      return null;
-    }
 
-    ByteBuffer sendBuffer = ByteBuffer.allocate(receiveBuffer.limit());
-    receiveBuffer.rewind();
-    sendBuffer.put(receiveBuffer);
-    // Cast to avoid issue with java version mismatch: https://stackoverflow.com/a/61267496/2875073
-    ((Buffer) sendBuffer).flip();
-    return sendBuffer;
+      logger.atSevere().log("IT IS HAPPENING!!!22222");
+      logger.atFine().log(
+          EmuUtil.formatSocketAddress(fromAddress)
+              + " -> "
+              + EmuUtil.formatSocketAddress(toAddress)
+              + ": "
+              + inMessage);
+
+      if (inMessage instanceof ConnectMessage_HELLOD00D) {
+        ConnectMessage_HELLOD00D portMsg = (ConnectMessage_HELLOD00D) inMessage;
+        logger.atInfo().log("Starting client relay on port " + (portMsg.getPort() - 1));
+
+        try {
+          v086RelayFactory.create(
+              portMsg.getPort(),
+              new InetSocketAddress(getServerSocketAddress().getAddress(), portMsg.getPort()));
+        } catch (Exception e) {
+          logger.atSevere().withCause(e).log("Failed to start!");
+          return null;
+        }
+      } else if (inMessage instanceof ConnectMessage_TOO) {
+        logger.atWarning().log("Failed to connect: Server is FULL!");
+      } else {
+        logger.atWarning().log("Server sent an invalid message: " + inMessage);
+        return null;
+      }
+
+      ByteBuffer sendBuffer = ByteBuffer.allocate(receiveBuffer.limit());
+      receiveBuffer.rewind();
+      sendBuffer.put(receiveBuffer);
+      // Cast to avoid issue with java version mismatch:
+      // https://stackoverflow.com/a/61267496/2875073
+      ((Buffer) sendBuffer).flip();
+      return sendBuffer;
+    }
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/relay/V086Relay.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/relay/V086Relay.java
@@ -1,6 +1,11 @@
 package org.emulinker.kaillera.relay;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.google.common.flogger.FluentLogger;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
 import java.net.InetSocketAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -9,13 +14,23 @@ import org.emulinker.kaillera.controller.v086.protocol.*;
 import org.emulinker.net.UDPRelay;
 import org.emulinker.util.EmuUtil;
 
-public class V086Relay extends UDPRelay {
+public final class V086Relay extends UDPRelay {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private int lastServerMessageNumber = -1;
   private int lastClientMessageNumber = -1;
 
-  public V086Relay(int listenPort, InetSocketAddress serverSocketAddress) throws Exception {
+  @AssistedFactory
+  public static interface Factory {
+    public V086Relay create(int listenPort, InetSocketAddress serverSocketAddress);
+  }
+
+  // TODO(nue): Check to see if this works.. i think it doesn't.
+  @AssistedInject
+  V086Relay(
+      @Assisted int listenPort,
+      @Assisted InetSocketAddress serverSocketAddress)
+      throws Exception {
     super(listenPort, serverSocketAddress);
   }
 
@@ -26,7 +41,7 @@ public class V086Relay extends UDPRelay {
 
   @Override
   protected ByteBuffer processClientToServer(
-      ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
+    ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
     V086Bundle inBundle = null;
 
     logger.atFine().log("-> " + EmuUtil.dumpBuffer(receiveBuffer));
@@ -69,7 +84,7 @@ public class V086Relay extends UDPRelay {
 
   @Override
   protected ByteBuffer processServerToClient(
-      ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
+    ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
     V086Bundle inBundle = null;
 
     logger.atFine().log("<- " + EmuUtil.dumpBuffer(receiveBuffer));

--- a/emulinker/src/main/java/org/emulinker/kaillera/relay/V086Relay.java
+++ b/emulinker/src/main/java/org/emulinker/kaillera/relay/V086Relay.java
@@ -1,7 +1,5 @@
 package org.emulinker.kaillera.relay;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.common.flogger.FluentLogger;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
@@ -21,16 +19,12 @@ public final class V086Relay extends UDPRelay {
   private int lastClientMessageNumber = -1;
 
   @AssistedFactory
-  public static interface Factory {
-    public V086Relay create(int listenPort, InetSocketAddress serverSocketAddress);
+  public interface Factory {
+    V086Relay create(int listenPort, InetSocketAddress serverSocketAddress);
   }
 
-  // TODO(nue): Check to see if this works.. i think it doesn't.
   @AssistedInject
-  V086Relay(
-      @Assisted int listenPort,
-      @Assisted InetSocketAddress serverSocketAddress)
-      throws Exception {
+  V086Relay(@Assisted int listenPort, @Assisted InetSocketAddress serverSocketAddress) {
     super(listenPort, serverSocketAddress);
   }
 
@@ -41,7 +35,7 @@ public final class V086Relay extends UDPRelay {
 
   @Override
   protected ByteBuffer processClientToServer(
-    ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
+      ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
     V086Bundle inBundle = null;
 
     logger.atFine().log("-> " + EmuUtil.dumpBuffer(receiveBuffer));
@@ -84,7 +78,7 @@ public final class V086Relay extends UDPRelay {
 
   @Override
   protected ByteBuffer processServerToClient(
-    ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
+      ByteBuffer receiveBuffer, InetSocketAddress fromAddress, InetSocketAddress toAddress) {
     V086Bundle inBundle = null;
 
     logger.atFine().log("<- " + EmuUtil.dumpBuffer(receiveBuffer));

--- a/emulinker/src/main/java/org/emulinker/net/PrivateUDPServer.java
+++ b/emulinker/src/main/java/org/emulinker/net/PrivateUDPServer.java
@@ -1,5 +1,6 @@
 package org.emulinker.net;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.flogger.FluentLogger;
 import java.net.*;
 import java.nio.ByteBuffer;
@@ -11,8 +12,9 @@ public abstract class PrivateUDPServer extends UDPServer {
   private InetAddress remoteAddress;
   private InetSocketAddress remoteSocketAddress;
 
-  public PrivateUDPServer(boolean shutdownOnExit, InetAddress remoteAddress) {
-    super(shutdownOnExit);
+  public PrivateUDPServer(
+      boolean shutdownOnExit, InetAddress remoteAddress, MetricRegistry metrics) {
+    super(shutdownOnExit, metrics);
     this.remoteAddress = remoteAddress;
   }
 

--- a/emulinker/src/main/java/org/emulinker/net/UDPRelay.java
+++ b/emulinker/src/main/java/org/emulinker/net/UDPRelay.java
@@ -1,6 +1,7 @@
 package org.emulinker.net;
 
 import com.google.common.flogger.FluentLogger;
+import java.io.IOException;
 import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
@@ -21,12 +22,19 @@ public abstract class UDPRelay implements Runnable {
   protected Map<InetSocketAddress, ClientHandler> clients =
       Collections.synchronizedMap(new HashMap<InetSocketAddress, ClientHandler>());
 
-  public UDPRelay(int listenPort, InetSocketAddress serverSocketAddress) throws Exception {
+  public UDPRelay(int listenPort, InetSocketAddress serverSocketAddress) {
     this.listenPort = listenPort;
     this.serverSocketAddress = serverSocketAddress;
 
-    listenChannel = DatagramChannel.open();
-    listenChannel.socket().bind(new InetSocketAddress(InetAddress.getLocalHost(), this.listenPort));
+    try {
+      listenChannel = DatagramChannel.open();
+      listenChannel
+          .socket()
+          .bind(new InetSocketAddress(InetAddress.getLocalHost(), this.listenPort));
+    } catch (IOException e) {
+      logger.atSevere().withCause(e).log("Failed to bind to channel");
+      throw new IllegalStateException(e);
+    }
 
     logger.atInfo().log("Bound to port " + listenPort);
 


### PR DESCRIPTION
Adds the following config properties:

```
# Enables server metrics to be monitored and logged.
metrics.enabled=false
# How often the metrics should be saved to a file in seconds.
metrics.loggingFrequencySeconds=15

# Core number of threads to be used. Default value 5.
server.coreThreadpoolSize=5
```

Application-level and JVM metrics will be logged to CSV files in the `metrics/` directory generated at runtime.

Also adds `@AssistedInject` onto some classes.